### PR TITLE
Added html manager and example ui

### DIFF
--- a/client/game.js
+++ b/client/game.js
@@ -1,6 +1,9 @@
 // Test av att importera ett skript med en funktion från en annan fil (som exempel)
 import { testPrint } from "./shared/test_shared.js";
+import { HtmlManager}  from "./htmlmanager/htmlmanager.js"
 testPrint(); // Ska skriva ut i konsolen
+
+const htmlManager = new HtmlManager(document.getElementById("ui"));
 
 // Game klassen (skulle kunna sättas i egen fil men detta funkar bra än så länge)
 class Game extends Phaser.Scene {
@@ -8,6 +11,14 @@ class Game extends Phaser.Scene {
         // Rita en röd testcirkel i mitten av skärmen
         const graphics = this.add.graphics({fillStyle:{color: 0xff0000}});
         graphics.fillCircle(this.scale.width/2,this.scale.height/2,40);
+
+        // Ladda in test UI och sätt upp så att något händer om man klickar på knappen
+        htmlManager.loadAll(["./ui/testui.html"]).then(() => {
+            let testui = htmlManager.create("testui");
+            testui.testbutton.onclick = () => {
+                testui.testtext.innerText = "Du klickade på knappen!";
+            }
+        })
     }
 }
 

--- a/client/htmlmanager/htmlmanager.css
+++ b/client/htmlmanager/htmlmanager.css
@@ -1,0 +1,74 @@
+/* CSS använd av htmlmanager, css för ui i allmänhet bör placeras i en annan fil */
+
+:root {
+    --edge-padding: 1rem;
+}
+
+#game {
+    position: relative;
+    width: min-content;
+    height: min-content;
+    margin-inline: auto;
+}
+
+#ui {
+    position: absolute;
+    /*Positionera ui så att det som standard alltid finns en marginal till kanten av spelskärmen*/
+    top: var(--edge-padding);
+    left: var(--edge-padding);
+    width: calc(100% - var(--edge-padding) * 2);
+    height: calc(100% - var(--edge-padding) * 2);
+    box-sizing: border-box;
+}
+
+#ui > * {
+    position: absolute;
+}
+
+/*Stilar under ska kombineras t.ex. center bottom för att få ui att vara centerarat längst med nedre kanten*/
+.center {
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%,-50%);
+}
+
+.left {
+    left: 0px;
+}
+
+.top {
+    top: 0px;
+}
+
+.bottom {
+    bottom: 0px;
+    top: unset;
+}
+
+.right {
+    right: 0px;
+    left: unset;
+}
+
+.fill {
+    width: 100%;
+    height: 100%;
+    box-sizing: border-box;
+}
+
+.left.fill, .right.fill {
+    width: fit-content;
+}
+
+.top.fill, .bottom.fill {
+    height: fit-content;
+}
+
+
+.left.center, .right.center {
+    transform: translateY(-50%);
+}
+
+.top.center, .bottom.center {
+    transform: translateX(-50%);
+}

--- a/client/htmlmanager/htmlmanager.js
+++ b/client/htmlmanager/htmlmanager.js
@@ -1,0 +1,201 @@
+export class HtmlManager {
+    cache = {}
+    cacheShort = {}
+    baseURL
+    parent
+    instances = []
+    /**
+     * 
+     * @param {*} parent The default DOM element to add things under 
+     * @param {*} baseURL The base URL used when loading files
+     */
+    constructor(parent, baseURL = "") {
+        if (parent == undefined) {
+            throw new Error("Parent is not set");
+        }
+        
+        this.parent = parent
+        this.baseURL = baseURL;
+        // Create css for handling hidden elements
+        const customStyle = document.createElement("style")
+        document.head.appendChild(customStyle)
+        customStyle.sheet.insertRule(".hidden {display: none !important;}")
+    }
+
+    getCachedContents(path) {
+        if (this.cacheShort[path] !== undefined) {
+            return this.cacheShort[path];
+        }
+        if (this.cache[path] === undefined) {
+            throw new Error(`${path} has not been loaded with HtmlLoader.load()`)
+        }
+        return this.cache[path];
+    }
+
+    async fetchHtmlContents(path) {
+        const response = await fetch(this.baseURL+path);
+        if (!response.ok) {
+            throw new Error(`Error when fetching ${this.baseURL+path}: ${response.status}`)
+        } 
+        const htmltext = await response.text()
+        
+        return htmltext
+    }
+
+    /**
+     * Load multiple files at once, waiting for them all in parallel
+     * @param {*} paths 
+     */
+    async loadAll(paths) {
+        const calls = []
+        for (let path of paths) {
+            calls.push(this.load(path))
+        }
+        await Promise.all(calls) // Wait until everything has been fetched
+    }
+
+    // Returns file name of path, ex: "ui/panel.hmtl" becomes "panel"
+    getShortName(path) {
+        let short = path.split("/").pop() // Grabs file name
+        return short.split(".")[0];
+    }
+
+    /**
+     * Load a html file into cache to be used later
+     * @param {*} path 
+     */
+    async load(path) {
+        let content = await this.fetchHtmlContents(path);
+        this.cache[path] = content;
+        // If multiple files has the same short name, the last loaded will be valid
+        this.cacheShort[this.getShortName(path)] = content
+    }
+    
+    /**
+     * 
+     * @param {string} path The path or name of the html file that's been loaded earlier
+     * @param {Object} placeholders Values to set placeholders (if any)
+     */
+    create(path,placeholders={},parent=this.parent) {
+        const html = this.getCachedContents(path);
+        const newInstance = new HTMLInstance(parent,html);
+        if (Object.keys(placeholders).length > 0) {
+            newInstance.setPlaceholders(placeholders)
+        }
+        this.instances.push(newInstance);
+        return newInstance;
+    }
+
+    /**
+     * Shows showInstance and hides all instances sharing the same parent as showInstance
+     * @param {*} showInstance 
+     */
+    showOnly(showInstance) {
+        for (let instance of this.instances) {
+            if (instance === showInstance) {
+                instance.show();
+            } else if (instance.parentNode === showInstance.parentNode) {
+                instance.hide();
+            }
+        }
+    }
+
+    /**
+     * Helper function to show a hidden html element
+     * @param {*} element 
+     */
+    static show(element) {
+        element.classList.remove("hidden")
+    }
+    
+    /**
+     * Helper function to hide a html element
+     * @param {*} element 
+     */
+    static hide(element) {
+        element.classList.add("hidden")
+    }
+}
+
+class HTMLInstance {
+    root;
+    placeholderNodes = {}
+
+    constructor(parent, html) {
+        this.parent = parent
+        const tempNode = document.createElement("div");
+        tempNode.innerHTML = html;
+        const contents = tempNode.firstChild;
+        this.root = contents
+        this.placeholderNodes = this.findPlaceholders();
+        parent.appendChild(contents);
+        this.findIds(this.root)
+    }
+
+    findPlaceholders() {
+        // Go through all text in the instance, finding {tags}. Place them in a dictionary to be adressed later.
+        let walker = document.createTreeWalker(this.root,NodeFilter.SHOW_TEXT)
+        const foundPlaceholders = {};
+        const regex = /{(\S)+}/g;
+        while (walker.nextNode()) {
+            const node = walker.currentNode;
+            let match;
+            if ((match = regex.exec(node.nodeValue)) !== null) {
+                const pKey = match[0];
+                const key = pKey.slice(1,pKey.length-1);
+                
+                const split = node.nodeValue.split(pKey,2) // Split only the first one. Leave the rest of the string for treewalker to deal with
+                const before = document.createTextNode(split[0])
+                const placeholder = document.createTextNode(key)
+                foundPlaceholders[key] = placeholder
+                const after = document.createTextNode(split[1])
+                // Add the nodes so that the order is the same as before, but split up
+                node.parentNode.insertBefore(before,node) 
+                node.parentNode.insertBefore(placeholder,node) 
+                node.parentNode.insertBefore(after,node) 
+                node.parentNode.removeChild(node)
+                walker.currentNode = after; // Move the search position to the end of this replacement
+            }
+        }
+        return foundPlaceholders
+    }
+
+    setPlaceholders(keys) {
+        for (let [key, value] of Object.entries(keys)) {
+            this.setPlaceholder(key,value)
+        }
+    }
+
+    setPlaceholder(key,value) {
+        if (this.placeholderNodes[key] === undefined) {
+            throw new Error("Couldn't find placeholder: "+key)
+        }
+        this.placeholderNodes[key].nodeValue = value;
+    }
+
+    findIds(parent) {
+        for (let child of parent.children) {
+            if (child.id !== "") {
+                this[child.id] = child;
+            }
+            this.findIds(child);
+        }
+    }
+
+    hide() {
+        HtmlManager.hide(this.root);
+    }
+
+    /**
+     * Hides this instance, and show another one 
+     * @param {*} instance 
+     */
+    switchTo(instance) {
+        this.hide();
+        instance.show();
+    }
+
+    show() {
+        HtmlManager.show(this.root);
+    }
+}

--- a/client/index.html
+++ b/client/index.html
@@ -6,11 +6,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="htmlmanager/htmlmanager.css">
     <title>Virus VS Antivirus</title>
 </head>
 <body>
     <div id="game">
-
+        <div id="ui"></div>
+        <!--Phaser kommer sätta in canvas här-->
     </div>
 </body>
 </html>

--- a/client/style.css
+++ b/client/style.css
@@ -2,3 +2,10 @@
 body, html {
     margin: 0;
 }
+
+/*Stil för testui*/
+.panel {
+    padding: 1em;
+    background-color: darkgray;
+    border: 2px solid gray;
+}

--- a/client/ui/testui.html
+++ b/client/ui/testui.html
@@ -1,0 +1,4 @@
+<div class="panel right bottom">
+    <p id="testtext" style="margin-top: 0;">Test ui</p>
+    <button id="testbutton">Testknapp</button>
+</div>


### PR DESCRIPTION
Html manager added along with a tiny example ui panel in the bottom right corner.

The position can easily be changed by changing the classes of the main div in the testui.html file. Right now its "bottom right" but this can for example be:
- `top left`
- `center`
- `left fill`
- `bottom center`
The styles for these positions is in `htmlmanager.css` and shouldn't need to be changed in the future.